### PR TITLE
Remove article limit from config

### DIFF
--- a/colino/config.py
+++ b/colino/config.py
@@ -52,16 +52,6 @@ class Config:
         return "https://oqh6f9ear9.execute-api.us-east-1.amazonaws.com/Prod"
 
     @property
-    def YOUTUBE_MAX_RESULTS(self) -> int:
-        return cast(int, self._config.get("youtube", {}).get("max_results", 50))
-
-    @property
-    def YOUTUBE_EXTRACT_TRANSCRIPTS(self) -> bool:
-        return cast(
-            bool, self._config.get("youtube", {}).get("extract_transcripts", True)
-        )
-
-    @property
     def YOUTUBE_TRANSCRIPT_LANGUAGES(self) -> list[str]:
         return cast(
             list[str],

--- a/colino/config.py
+++ b/colino/config.py
@@ -85,10 +85,6 @@ class Config:
         return cast(str, self._config.get("ai", {}).get("model", "gpt-5-mini"))
 
     @property
-    def LLM_MAX_ARTICLES(self) -> int:
-        return cast(int, self._config.get("ai", {}).get("max_articles", 10))
-
-    @property
     def AI_AUTO_SAVE(self) -> bool:
         return cast(bool, self._config.get("ai", {}).get("auto_save", True))
 

--- a/colino/config.py
+++ b/colino/config.py
@@ -82,7 +82,7 @@ class Config:
 
     @property
     def LLM_MODEL(self) -> str:
-        return cast(str, self._config.get("ai", {}).get("model", "gpt-3.5-turbo"))
+        return cast(str, self._config.get("ai", {}).get("model", "gpt-5-mini"))
 
     @property
     def LLM_MAX_ARTICLES(self) -> int:

--- a/colino/digest_manager.py
+++ b/colino/digest_manager.py
@@ -323,9 +323,9 @@ class DigestManager:
             return posts[:max_articles]
 
         # Group posts by source
-        posts_by_source = {}
+        posts_by_source: dict[str, list[dict[str, Any]]] = {}
         for post in posts:
-            post_source = post.get("source")
+            post_source = post.get("source") or "unknown"
             if post_source not in posts_by_source:
                 posts_by_source[post_source] = []
             posts_by_source[post_source].append(post)

--- a/colino/digest_manager.py
+++ b/colino/digest_manager.py
@@ -316,7 +316,7 @@ class DigestManager:
             return posts[:max_articles]
 
         # Check if we have multiple sources
-        sources_in_posts = set(post.get("source") for post in posts)
+        sources_in_posts = {post.get("source") for post in posts}
 
         # If only one source present, just limit
         if len(sources_in_posts) <= 1:
@@ -344,7 +344,9 @@ class DigestManager:
             source_limit = posts_per_source + (1 if i < remainder else 0)
             balanced_posts.extend(source_posts[:source_limit])
 
-        logger.info(f"Balanced {len(balanced_posts)} posts across {num_sources} sources (limit: {max_articles})")
+        logger.info(
+            f"Balanced {len(balanced_posts)} posts across {num_sources} sources (limit: {max_articles})"
+        )
 
         # Sort by creation time to maintain chronological order
         balanced_posts.sort(key=lambda x: x.get("created_at", ""), reverse=True)

--- a/colino/main.py
+++ b/colino/main.py
@@ -202,9 +202,10 @@ def main() -> None:
         help="Skip automatic ingestion of recent sources before digesting",
     )
     digest_parser.add_argument(
-        "--limit", type=int,
+        "--limit",
+        type=int,
         help="Maximum number of articles to include in digest",
-        default=100
+        default=100,
     )
 
     args = parser.parse_args()

--- a/colino/main.py
+++ b/colino/main.py
@@ -252,7 +252,9 @@ def main() -> None:
                 digest_url(args.url, args.output)
             elif args.rss:
                 # Digest recent RSS articles
-                generate_digest(args.hours, args.output, "rss", not args.skip_ingest, args.limit)
+                generate_digest(
+                    args.hours, args.output, "rss", not args.skip_ingest, args.limit
+                )
             elif args.youtube:
                 # Digest recent YouTube videos
                 generate_digest(
@@ -260,7 +262,9 @@ def main() -> None:
                 )
             else:
                 # Digest recent articles from all sources
-                generate_digest(args.hours, args.output, None, not args.skip_ingest, args.limit)
+                generate_digest(
+                    args.hours, args.output, None, not args.skip_ingest, args.limit
+                )
 
     except KeyboardInterrupt:
         get_logger().info("Operation cancelled by user")

--- a/colino/main.py
+++ b/colino/main.py
@@ -93,11 +93,12 @@ def generate_digest(
     output_file: str | None = None,
     source: str | None = None,
     auto_ingest: bool = True,
+    limit: int | None = None,
 ) -> bool:
     """Generate an AI-powered digest of recent articles"""
     digest_manager = DigestManager()
     return digest_manager.digest_recent_articles(
-        hours, output_file, source, auto_ingest
+        hours, output_file, source, auto_ingest, limit
     )
 
 
@@ -200,6 +201,9 @@ def main() -> None:
         action="store_true",
         help="Skip automatic ingestion of recent sources before digesting",
     )
+    digest_parser.add_argument(
+        "--limit", type=int, help="Maximum number of articles to include in digest"
+    )
 
     args = parser.parse_args()
 
@@ -248,15 +252,15 @@ def main() -> None:
                 digest_url(args.url, args.output)
             elif args.rss:
                 # Digest recent RSS articles
-                generate_digest(args.hours, args.output, "rss", not args.skip_ingest)
+                generate_digest(args.hours, args.output, "rss", not args.skip_ingest, args.limit)
             elif args.youtube:
                 # Digest recent YouTube videos
                 generate_digest(
-                    args.hours, args.output, "youtube", not args.skip_ingest
+                    args.hours, args.output, "youtube", not args.skip_ingest, args.limit
                 )
             else:
                 # Digest recent articles from all sources
-                generate_digest(args.hours, args.output, None, not args.skip_ingest)
+                generate_digest(args.hours, args.output, None, not args.skip_ingest, args.limit)
 
     except KeyboardInterrupt:
         get_logger().info("Operation cancelled by user")

--- a/colino/main.py
+++ b/colino/main.py
@@ -202,7 +202,9 @@ def main() -> None:
         help="Skip automatic ingestion of recent sources before digesting",
     )
     digest_parser.add_argument(
-        "--limit", type=int, help="Maximum number of articles to include in digest"
+        "--limit", type=int,
+        help="Maximum number of articles to include in digest",
+        default=100
     )
 
     args = parser.parse_args()

--- a/colino/sources/youtube.py
+++ b/colino/sources/youtube.py
@@ -211,9 +211,6 @@ class YouTubeSource(BaseSource):
     def get_video_transcript(self, video_id: str) -> str | None:
         """Get transcript for a YouTube video"""
 
-        if not config.YOUTUBE_EXTRACT_TRANSCRIPTS:
-            return None
-
         try:
             # Try to get transcript in preferred languages
             languages = config.YOUTUBE_TRANSCRIPT_LANGUAGES

--- a/colino/summarize.py
+++ b/colino/summarize.py
@@ -129,7 +129,9 @@ class DigestGenerator:
         template = Template(template_content)
         return template.render(article=template_article)
 
-    def summarize_articles(self, articles: list[dict[str, Any]], limit: int | None = None) -> str:
+    def summarize_articles(
+        self, articles: list[dict[str, Any]], limit: int | None = None
+    ) -> str:
         """Generate a digest summary of multiple articles"""
         # Apply limit if provided
         if limit is not None:

--- a/colino/summarize.py
+++ b/colino/summarize.py
@@ -129,10 +129,11 @@ class DigestGenerator:
         template = Template(template_content)
         return template.render(article=template_article)
 
-    def summarize_articles(self, articles: list[dict[str, Any]]) -> str:
+    def summarize_articles(self, articles: list[dict[str, Any]], limit: int | None = None) -> str:
         """Generate a digest summary of multiple articles"""
-        # Limit number of articles to process
-        articles = articles[: config.LLM_MAX_ARTICLES]
+        # Apply limit if provided
+        if limit is not None:
+            articles = articles[:limit]
         logger.info(f"Generating digest for {len(articles)} articles")
 
         # Prepare article content for LLM

--- a/config.yaml
+++ b/config.yaml
@@ -35,7 +35,6 @@ ai:
   
   # Model settings
   model: "gpt-5-mini"
-  max_articles: 100
   extract_web_content: true
   
   # Digest auto-save


### PR DESCRIPTION
# Description

This change introduces a new limit parameter for the digest command, that's used to limit the amount of articles to digest.
At the same time we remove the obsolete config parameter doing the same thing